### PR TITLE
Separate API docs pages from tutorial pages

### DIFF
--- a/src/components/AppNavbar.vue
+++ b/src/components/AppNavbar.vue
@@ -4,8 +4,9 @@
       <router-link to="/">discord-akairo</router-link>
 
       <nav>
-        <router-link to="/docs">Documentation</router-link><!--
-        --><a :href="`https://github.com/${repository}`">GitHub</a>
+        <router-link :to="{ name: 'docs' }">Documentation</router-link>
+        <router-link :to="{ name: 'docs-file' }">Tutorials</router-link>
+        <a :href="`https://github.com/${repository}`">GitHub</a>
       </nav>
     </container>
   </header>

--- a/src/components/docs/Sidebar.vue
+++ b/src/components/docs/Sidebar.vue
@@ -10,40 +10,44 @@
       <em id="docs-visibility" class="fa toggle" :class="showPrivate ? 'fa-eye' : 'fa-eye-slash'" :title="togglePrivateLabel" @click="togglePrivate"></em>
       <em id="docs-brightness" class="fa toggle" :class="darkMode ? 'fa-moon-o' : 'fa-sun-o'" :title="toggleDarkModeLabel" @click="toggleDarkMode"></em>
 
-      <ul>
-        <li v-for="(category, categoryID) in docs.custom" :key="categoryID">
-          {{ category.name }}
-          <ul>
-            <li v-for="(file, fileID) in category.files" :key="fileID">
-              <router-link :to="{ name: 'docs-file', params: { category: categoryID, file: fileID } }">
-                {{ file.name }}
-              </router-link>
-            </li>
-          </ul>
-        </li>
+      <transition name="fade-slide" mode="out-in">
+        <ul v-if="showTutorialsSidebar">
+          <li v-for="(category, categoryID) in docs.custom" :key="categoryID">
+            {{ category.name }}
+            <ul>
+              <li v-for="(file, fileID) in category.files" :key="fileID">
+                <router-link :to="{ name: 'docs-file', params: { category: categoryID, file: fileID } }">
+                  {{ file.name }}
+                </router-link>
+              </li>
+            </ul>
+          </li>
+        </ul>
 
-        <li>
-          Classes
-          <transition-group name="animated-list" tag="ul">
-            <li v-for="clarse in docs.classes" v-if="showPrivate || clarse.access !== 'private'" :key="clarse.name" class="animated-list-item">
-              <router-link exact :to="{ name: 'docs-class', params: { class: clarse.name } }">
-                {{ clarse.name }}
-              </router-link>
-            </li>
-          </transition-group>
-        </li>
+        <ul v-else key="docs-sidebar">
+          <li>
+            Classes
+            <transition-group name="animated-list" tag="ul">
+              <li v-for="clarse in docs.classes" v-if="showPrivate || clarse.access !== 'private'" :key="clarse.name" class="animated-list-item">
+                <router-link exact :to="{ name: 'docs-class', params: { class: clarse.name } }">
+                  {{ clarse.name }}
+                </router-link>
+              </li>
+            </transition-group>
+          </li>
 
-        <li>
-          Typedefs
-          <ul>
-            <li v-for="typedef in docs.typedefs" v-if="showPrivate || typedef.access !== 'private'" :key="typedef.name">
-              <router-link exact :to="{ name: 'docs-typedef', params: { typedef: typedef.name } }">
-                {{ typedef.name }}
-              </router-link>
-            </li>
-          </ul>
-        </li>
-      </ul>
+          <li>
+            Typedefs
+            <ul>
+              <li v-for="typedef in docs.typedefs" v-if="showPrivate || typedef.access !== 'private'" :key="typedef.name">
+                <router-link exact :to="{ name: 'docs-typedef', params: { typedef: typedef.name } }">
+                  {{ typedef.name }}
+                </router-link>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </transition>
     </div>
   </div>
 </template>
@@ -61,6 +65,11 @@
     },
 
     computed: {
+      showTutorialsSidebar() {
+        // eslint-disable-next-line eqeqeq
+        return this.$route.params.category != null;
+      },
+
       togglePrivateLabel() {
         return `Private items are ${this.showPrivate ? 'shown' : 'hidden'}. Click to toggle.`;
       },
@@ -156,6 +165,7 @@
     }
 
     ul {
+      min-width: 200px;
       margin: 0 0 16px 0;
       padding: 0;
       list-style: none;

--- a/src/components/pages/Documentation.vue
+++ b/src/components/pages/Documentation.vue
@@ -41,11 +41,10 @@
         if (route.params.source && this.sources[route.params.source]) {
           this.setSource(route.params.source);
         } else {
-          this.$router.replace({ name: 'docs-file', params: {
+          this.$router.replace({ name: 'docs-class', params: {
             source: MainSource.id,
             tag: MainSource.defaultTag,
-            category: MainSource.defaultFile.category,
-            file: MainSource.defaultFile.id,
+            class: MainSource.defaultClass,
           } });
           return;
         }

--- a/src/data/DocsSource.js
+++ b/src/data/DocsSource.js
@@ -12,6 +12,7 @@ export default class DocsSource {
     this.global = options.global;
     this.repo = options.repo;
     this.defaultTag = options.defaultTag || 'master';
+    this.defaultClass = options.defaultClass;
     this.defaultFile = options.defaultFile || { category: 'general', id: 'welcome' };
     this.source = options.source || `https://github.com/${this.repo}/blob/`;
     this.branchFilter = options.branchFilter || (branch => branch !== 'master');

--- a/src/data/MainSource.js
+++ b/src/data/MainSource.js
@@ -8,6 +8,7 @@ export default new DocsSource({
   global: 'Akairo',
   repo: 'discord-akairo/discord-akairo',
   defaultTag: 'master',
+  defaultClass: 'AkairoClient',
   branchFilter: branch => !branchBlacklist.has(branch) && !branch.startsWith('dependabot/'),
   tagFilter: tag => semver.gte(tag, '7.0.0'),
 });


### PR DESCRIPTION
This PR adds a `Tutorials` link to the nav bar and displays the appropriate sidebar content depending on whether you're viewing the docs or the tutorials! 🎉 